### PR TITLE
Introduce @client.JsonRpcService

### DIFF
--- a/src/main/kotlin/com/hylamobile/voorhees/client/JsonRpcClient.kt
+++ b/src/main/kotlin/com/hylamobile/voorhees/client/JsonRpcClient.kt
@@ -5,6 +5,7 @@ import com.github.kittinunf.fuel.core.FuelManager
 import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.fuel.core.interceptors.LogRequestAsCurlInterceptor
 import com.github.kittinunf.fuel.httpPost
+import com.hylamobile.voorhees.client.annotation.JsonRpcService
 import com.hylamobile.voorhees.client.annotation.Param
 import com.hylamobile.voorhees.jsonrpc.*
 import java.lang.reflect.InvocationHandler
@@ -15,6 +16,15 @@ import java.nio.charset.Charset
 data class ServerConfig(val url: String)
 
 class JsonRpcClient(private val serverConfig: ServerConfig) {
+
+    fun <T> getService(type: Class<T>): T {
+        val anno = type.getAnnotation(JsonRpcService::class.java)
+
+        requireNotNull(anno) { "Class ${type.name} should be annotated with JsonRpcService annotation" }
+        check(anno.location.isNotEmpty()) { "@JsonRpcService on ${type.name} should have location set" }
+
+        return getService(anno.location, type)
+    }
 
     fun <T> getService(location: String, type: Class<T>): T =
         Proxy.newProxyInstance(type.classLoader,

--- a/src/main/kotlin/com/hylamobile/voorhees/client/annotation/JsonRpcService.kt
+++ b/src/main/kotlin/com/hylamobile/voorhees/client/annotation/JsonRpcService.kt
@@ -1,0 +1,6 @@
+package com.hylamobile.voorhees.client.annotation
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+annotation class JsonRpcService(val location: String)

--- a/src/test/kotlin/com/hylamobile/voorhees/spring/WebServiceTest.kt
+++ b/src/test/kotlin/com/hylamobile/voorhees/spring/WebServiceTest.kt
@@ -3,6 +3,7 @@ package com.hylamobile.voorhees.spring
 import com.fasterxml.jackson.databind.node.TextNode
 import com.hylamobile.voorhees.client.JsonRpcClient
 import com.hylamobile.voorhees.client.ServerConfig
+import com.hylamobile.voorhees.client.annotation.JsonRpcService
 import com.hylamobile.voorhees.client.annotation.Param
 import com.hylamobile.voorhees.jsonrpc.ErrorCode
 import com.hylamobile.voorhees.jsonrpc.JsonRpcException
@@ -18,6 +19,7 @@ import org.springframework.test.context.junit4.SpringRunner
 class WebServiceTest {
 
     companion object {
+        @JsonRpcService(location = "/test")
         interface RemoteService {
             fun plus(l: Int, r: Int): Int
 
@@ -32,18 +34,19 @@ class WebServiceTest {
     @LocalServerPort
     var localServerPort: Int = 0
 
+    private val client
+        get() = JsonRpcClient(ServerConfig("http://localhost:$localServerPort"))
+
     @Test
     fun testRemote() {
-        val client = JsonRpcClient(ServerConfig("http://localhost:${localServerPort}"))
-        val testService = client.getService("/test", RemoteService::class.java)
+        val testService = client.getService(RemoteService::class.java)
         val result = testService.plus(3, 4)
         assertEquals(7, result)
     }
 
     @Test
     fun testDefault() {
-        val client = JsonRpcClient(ServerConfig("http://localhost:${localServerPort}"))
-        val testService = client.getService("/test", RemoteService::class.java)
+        val testService = client.getService(RemoteService::class.java)
         val result = testService.replicate("test")
         assertEquals("testtest", result)
     }
@@ -51,8 +54,7 @@ class WebServiceTest {
     @Test
     fun testJsonError() {
         try {
-            val client = JsonRpcClient(ServerConfig("http://localhost:${localServerPort}"))
-            val testService = client.getService("/test", RemoteService::class.java)
+            val testService = client.getService(RemoteService::class.java)
             testService.breakALeg()
         } catch (e: JsonRpcException) {
             assertEquals(ErrorCode.INTERNAL_ERROR.code, e.error.code)
@@ -64,8 +66,7 @@ class WebServiceTest {
     @Test
     fun testException() {
         try {
-            val client = JsonRpcClient(ServerConfig("http://localhost:${localServerPort}"))
-            val testService = client.getService("/test", RemoteService::class.java)
+            val testService = client.getService(RemoteService::class.java)
             testService.breakAnArm()
         } catch (e: JsonRpcException) {
             assertEquals(ErrorCode.INTERNAL_ERROR.code, e.error.code)


### PR DESCRIPTION
The @JsonRpcService annotation allows to bind the location of the remote
service to the proxy interface on the client side. So now there is no
need to pass a location when we need to get a remote service:

```java
MyService service = client.getService(MyService.class);
```

Fix #5