### PR TITLE
Use the only slash when concat url and endpoint

### DIFF
--- a/src/main/kotlin/com/hylamobile/voorhees/client/JsonRpcClient.kt
+++ b/src/main/kotlin/com/hylamobile/voorhees/client/JsonRpcClient.kt
@@ -30,9 +30,11 @@ open class JsonRpcClient(private val serverConfig: ServerConfig) {
     }
 
     @Suppress("UNCHECKED_CAST")
-    fun <T> getService(location: String, type: Class<T>): T =
-        Proxy.newProxyInstance(type.classLoader,
-            arrayOf(type), ServiceProxy(serverConfig.url + location)) as T
+    fun <T> getService(location: String, type: Class<T>): T {
+        val url = serverConfig.url + if (serverConfig.url.endsWith("/")) "" else "/"
+        val loc = if (location.startsWith("/")) location.substring(1) else location
+        return Proxy.newProxyInstance(type.classLoader, arrayOf(type), ServiceProxy(url + loc)) as T
+    }
 
     open fun updateOptions(options: RequestExecutionOptions) {
         serverConfig.connectTimeout?.also { options.timeoutInMillisecond = it }

--- a/src/test/kotlin/com/hylamobile/voorhees/spring/WebServiceTest.kt
+++ b/src/test/kotlin/com/hylamobile/voorhees/spring/WebServiceTest.kt
@@ -37,7 +37,7 @@ class WebServiceTest {
     var localServerPort: Int = 0
 
     private val client
-        get() = JsonRpcClient(ServerConfig("http://localhost:$localServerPort"))
+        get() = JsonRpcClient(ServerConfig("http://localhost:$localServerPort/"))
 
     @Test
     fun `regular call should work`() {


### PR DESCRIPTION
Fix #26