### PR TITLE
Add API prefix property

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ services in Spring applications in a quite fast and seamless way.
   * [Services](#services)
     * [Named Parameters](#named-parameters)
     * [Default Values](#default-values)
+    * [Endpoint Prefix](#endpoint-prefix)
   * [Client (Java)](#client-java)
   * [Client (Python)](#client-python)
   * [Exception Handling](#exception-handling)
@@ -159,6 +160,24 @@ Note that default values are strings keeping JSON representation of the
 default value. The only exception is string value. So if Voorhees is not
 able to parse default value, it uses it as is if the type of the
 parameter is String.
+
+### Endpoint Prefix
+
+In order to specify the common API prefix for all JSON RPC services use
+`spring.voorhees.server.api.prefix` Spring property:
+
+```yaml
+spring:
+  voorhees:
+    server:
+      api:
+        prefix: /api
+```
+
+Note that it should start with slash or be an empty string.
+
+For example, if prefix is `/api` and service location is `/my` then the
+real enspoint is going to be `/api/my`.
 
 ## Client (Java)
 

--- a/voorhees-client/src/main/kotlin/com/hylamobile/voorhees/client/JsonRpcClient.kt
+++ b/voorhees-client/src/main/kotlin/com/hylamobile/voorhees/client/JsonRpcClient.kt
@@ -6,6 +6,7 @@ import com.github.kittinunf.fuel.httpPost
 import com.hylamobile.voorhees.client.annotation.JsonRpcService
 import com.hylamobile.voorhees.client.annotation.Param
 import com.hylamobile.voorhees.jsonrpc.*
+import com.hylamobile.voorhees.util.uriCombine
 import java.lang.reflect.*
 import java.nio.charset.Charset
 
@@ -30,9 +31,8 @@ open class JsonRpcClient(private val serverConfig: ServerConfig) {
 
     @Suppress("UNCHECKED_CAST")
     fun <T> getService(location: String, type: Class<T>): T {
-        val url = serverConfig.url + if (serverConfig.url.endsWith("/")) "" else "/"
-        val loc = if (location.startsWith("/")) location.substring(1) else location
-        return Proxy.newProxyInstance(type.classLoader, arrayOf(type), ServiceProxy(url + loc)) as T
+        val path = uriCombine(serverConfig.url, location)
+        return Proxy.newProxyInstance(type.classLoader, arrayOf(type), ServiceProxy(path)) as T
     }
 
     open fun updateOptions(options: RequestExecutionOptions) {

--- a/voorhees-core/src/main/kotlin/com/hylamobile/voorhees/util/utils.kt
+++ b/voorhees-core/src/main/kotlin/com/hylamobile/voorhees/util/utils.kt
@@ -1,0 +1,7 @@
+package com.hylamobile.voorhees.util
+
+fun uriCombine(left: String, right: String): String {
+    val normalizedLeft = left + if (left.endsWith("/")) "" else "/"
+    val normalizedRight = if (right.startsWith("/")) right.substring(1) else right
+    return normalizedLeft + normalizedRight
+}

--- a/voorhees-server/src/main/kotlin/com/hylamobile/voorhees/server/spring/webmvc/JsonRpcHandlerMapping.kt
+++ b/voorhees-server/src/main/kotlin/com/hylamobile/voorhees/server/spring/webmvc/JsonRpcHandlerMapping.kt
@@ -4,6 +4,7 @@ import com.hylamobile.voorhees.jsonrpc.ErrorCode
 import com.hylamobile.voorhees.jsonrpc.Request
 import com.hylamobile.voorhees.server.annotations.DontExpose
 import com.hylamobile.voorhees.server.annotations.JsonRpcService
+import com.hylamobile.voorhees.util.uriCombine
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.Ordered
 import org.springframework.http.InvalidMediaTypeException
@@ -12,16 +13,22 @@ import org.springframework.web.servlet.handler.AbstractHandlerMapping
 import javax.annotation.PostConstruct
 import javax.servlet.http.HttpServletRequest
 
+typealias ServiceMethods = List<JsonRpcMethodHandler>
+typealias ServiceDescriptor = Map<String, ServiceMethods>
+
 class JsonRpcHandlerMapping : AbstractHandlerMapping() {
 
     @Value("\${spring.voorhees.server.handler-mapping.order:-2147483648}")
     private var _order: Int = Ordered.HIGHEST_PRECEDENCE
 
-    private lateinit var handlers: Map<String, Map<String, List<JsonRpcMethodHandler>>>
+    @Value("\${spring.voorhees.server.api.prefix:}")
+    private var apiPrefix: String = ""
+
+    private lateinit var serviceDescriptors: Map<String, ServiceDescriptor>
 
     @PostConstruct
     fun init() {
-        handlers = (applicationContext ?: throw IllegalStateException("Should not be thrown"))
+        serviceDescriptors = (applicationContext ?: throw IllegalStateException("Should not be thrown"))
             .getBeansWithAnnotation(JsonRpcService::class.java)
             .values
             .flatMap { bean ->
@@ -32,7 +39,7 @@ class JsonRpcHandlerMapping : AbstractHandlerMapping() {
                     .mapValues { it.value.map { m -> JsonRpcMethodHandler(bean, m) }}
 
                 val jsonRpcAnno = clazz.getAnnotation(JsonRpcService::class.java)
-                jsonRpcAnno.locations.map { it to handlerInfos }
+                jsonRpcAnno.locations.map { loc -> uriCombine(apiPrefix, loc) to handlerInfos }
             }
             .toMap()
     }
@@ -57,7 +64,7 @@ class JsonRpcHandlerMapping : AbstractHandlerMapping() {
     }
 
     private fun findHandler(httpRequest: HttpServletRequest): JsonRpcHandler? {
-        val serviceMethods = handlers[httpRequest.realPath] ?: return null
+        val serviceMethods = serviceDescriptors[httpRequest.realPath] ?: return null
 
         val jsonRequest: Request = httpRequest.jsonRequest
 

--- a/voorhees-server/src/test/kotlin/com/hylamobile/voorhees/server/spring/ServerTest.kt
+++ b/voorhees-server/src/test/kotlin/com/hylamobile/voorhees/server/spring/ServerTest.kt
@@ -57,7 +57,7 @@ open class WebSecurityConfig : WebSecurityConfigurerAdapter() {
         http
             .csrf().disable()
             .authorizeRequests()
-                .antMatchers("/secured").hasRole("ADMIN")
+                .antMatchers("/api/secured").hasRole("ADMIN")
                 .anyRequest().permitAll().and()
             .httpBasic()
     }

--- a/voorhees-server/src/test/kotlin/com/hylamobile/voorhees/server/spring/TestApp.kt
+++ b/voorhees-server/src/test/kotlin/com/hylamobile/voorhees/server/spring/TestApp.kt
@@ -1,6 +1,5 @@
 package com.hylamobile.voorhees.server.spring
 
-import com.hylamobile.voorhees.server.spring.annotation.EnableVoorhees
 import org.springframework.boot.autoconfigure.SpringBootApplication
 
 @SpringBootApplication

--- a/voorhees-server/src/test/kotlin/com/hylamobile/voorhees/server/spring/TestServiceTest.kt
+++ b/voorhees-server/src/test/kotlin/com/hylamobile/voorhees/server/spring/TestServiceTest.kt
@@ -27,7 +27,7 @@ class TestServiceTest {
     @Test
     fun `call method with positional parameters should succeed`() {
         val request = Request("plus", ByPositionParams(3, 4), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -43,7 +43,7 @@ class TestServiceTest {
     @Test
     fun `call method with named parameters should succeed`() {
         val request = Request("plus", ByNameParams("l" to 3, "r" to 4), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -58,7 +58,7 @@ class TestServiceTest {
     @Test
     fun `call of explicitly named parameters method with positional parameters should succeed`() {
         val request = Request("replicate", ByPositionParams("test", 3), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -74,7 +74,7 @@ class TestServiceTest {
     @Test
     fun `call of explicitly named parameters method with named parameters should succeed`() {
         val request = Request("replicate", ByNameParams("str" to "test", "times" to 3), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -89,7 +89,7 @@ class TestServiceTest {
     @Test
     fun `call of default-parameters method with unspecified parameter should succeed`() {
         val request = Request("replicate", ByNameParams("str" to "test"), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -104,7 +104,7 @@ class TestServiceTest {
     @Test
     fun `call of default-parameters method with null parameters should succeed`() {
         val request = Request("replicate", null, NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -119,7 +119,7 @@ class TestServiceTest {
     @Test
     fun `call of default-parameters method with empty positional parameters should succeed`() {
         val request = Request("replicate", ByPositionParams(), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -134,7 +134,7 @@ class TestServiceTest {
     @Test
     fun `call of default-parameters method with empty named parameters should succeed`() {
         val request = Request("replicate", ByNameParams(), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -149,7 +149,7 @@ class TestServiceTest {
     @Test
     fun `call of default-parameters method with short parameter list should succeed`() {
         val request = Request("replicate", ByPositionParams("test"), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -164,7 +164,7 @@ class TestServiceTest {
     @Test
     fun `call with null as parameters should succeed`() {
         val request = Request("theAnswer", null, NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -179,7 +179,7 @@ class TestServiceTest {
     @Test
     fun `call with empty positional parameters should succeed`() {
         val request = Request("theAnswer", ByPositionParams(), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -194,7 +194,7 @@ class TestServiceTest {
     @Test
     fun `call with empty named parameters should succeed`() {
         val request = Request("theAnswer", ByNameParams(), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -209,7 +209,7 @@ class TestServiceTest {
     @Test
     fun `call of absent method should fail`() {
         val request = Request("noSuchMethod", null, NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -226,7 +226,7 @@ class TestServiceTest {
     @Test
     fun `call with insufficient amount of positional parameters should fail`() {
         val request = Request("plus", ByPositionParams(3), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -243,7 +243,7 @@ class TestServiceTest {
     @Test
     fun `call with insufficient amount of named parameters should fail`() {
         val request = Request("plus", ByNameParams("l" to 3), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -260,7 +260,7 @@ class TestServiceTest {
     @Test
     fun `call with too many positional parameters should fail`() {
         val request = Request("plus", ByPositionParams(3, 4, 5), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -277,7 +277,7 @@ class TestServiceTest {
     @Test
     fun `call with too many named parameters should fail`() {
         val request = Request("plus", ByNameParams("l" to 3, "r" to 4, "m" to 5), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -294,7 +294,7 @@ class TestServiceTest {
     @Test
     fun `internal error should be handled`() {
         val request = Request("breakALeg", null, NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -311,7 +311,7 @@ class TestServiceTest {
     @Test
     fun `custom error should be handled`() {
         val request = Request("breakAnArm", null, NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -328,7 +328,7 @@ class TestServiceTest {
     @Test
     fun `@DontExpose methods should not be exposed`() {
         val request = Request("unexposed", null, NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -347,7 +347,7 @@ class TestServiceTest {
         val person = Person("johnny", 20)
 
         val request = Request("birthday", ByPositionParams(person), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -364,7 +364,7 @@ class TestServiceTest {
         val person = Person("johnny", 20)
 
         val request = Request("birthday", ByNameParams("person" to person), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -381,7 +381,7 @@ class TestServiceTest {
         val person = Person("johnny", 20)
 
         val request = Request("birthdays", ByPositionParams(listOf(person)), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -398,7 +398,7 @@ class TestServiceTest {
         val person = Person("johnny", 20)
 
         val request = Request("birthdays", ByNameParams("people" to listOf(person)), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(request.jsonString))
@@ -413,7 +413,7 @@ class TestServiceTest {
     @Test
     fun `Null should be parsed as default values`() {
         val request = Request("checkNullDefaultValues", null, NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
             .contentType(MediaType.APPLICATION_JSON_UTF8)
             .accept(MediaType.APPLICATION_JSON)
             .content(request.jsonString))
@@ -428,7 +428,7 @@ class TestServiceTest {
     @Test
     fun `Null should be parsed as default values if parameters are positional`() {
         val request = Request("checkNullDefaultValues", ByPositionParams(), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
             .contentType(MediaType.APPLICATION_JSON_UTF8)
             .accept(MediaType.APPLICATION_JSON)
             .content(request.jsonString))
@@ -443,7 +443,7 @@ class TestServiceTest {
     @Test
     fun `Null should be parsed as default values if parameters are named`() {
         val request = Request("checkNullDefaultValues", ByNameParams(), NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/test")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
             .contentType(MediaType.APPLICATION_JSON_UTF8)
             .accept(MediaType.APPLICATION_JSON)
             .content(request.jsonString))
@@ -458,7 +458,7 @@ class TestServiceTest {
     @Test
     fun `Secured endpoint should fail for anonymous`() {
         val request = Request("secret", null, NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/secured")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/secured")
             .contentType(MediaType.APPLICATION_JSON_UTF8)
             .accept(MediaType.APPLICATION_JSON)
             .content(request.jsonString))
@@ -469,7 +469,7 @@ class TestServiceTest {
     @Test
     fun `Secured endpoint should fail for unauthorized users`() {
         val request = Request("secret", null, NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/secured").basicAuth("user", "password")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/secured").basicAuth("user", "password")
             .contentType(MediaType.APPLICATION_JSON_UTF8)
             .accept(MediaType.APPLICATION_JSON)
             .content(request.jsonString))
@@ -480,7 +480,7 @@ class TestServiceTest {
     @Test
     fun `Secured endpoint should succeed for admins`() {
         val request = Request("secret", null, NumberId(1))
-        mockMvc.perform(MockMvcRequestBuilders.post("/secured").basicAuth("admin", "password")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/secured").basicAuth("admin", "password")
             .contentType(MediaType.APPLICATION_JSON_UTF8)
             .accept(MediaType.APPLICATION_JSON)
             .content(request.jsonString))

--- a/voorhees-server/src/test/resources/application.yml
+++ b/voorhees-server/src/test/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  voorhees:
+    server:
+      api:
+        prefix: /api


### PR DESCRIPTION
Now the common API prefix could be defined out of JSON RPC services. To
define it, use `spring.voorhees.server.api.prefix` Spring property. By
default it's empty string.

* Rename `handlers` to `serviceDescriptors`.
* typealiases are extracted.
* New behavior has been documented.

Fix #36