### PR TITLE
Handle HTTP errors properly

### DIFF
--- a/voorhees-server/src/main/kotlin/com/hylamobile/voorhees/server/spring/webmvc/ErrorHandler.kt
+++ b/voorhees-server/src/main/kotlin/com/hylamobile/voorhees/server/spring/webmvc/ErrorHandler.kt
@@ -1,0 +1,17 @@
+package com.hylamobile.voorhees.server.spring.webmvc
+
+import org.springframework.web.HttpRequestHandler
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class ErrorHandler(
+    private val statusCode: Int, 
+    private val body: String? = null) : HttpRequestHandler {
+
+    override fun handleRequest(request: HttpServletRequest, response: HttpServletResponse) {
+        if (body != null) {
+            response.writer.print(body)
+        }
+        response.sendError(statusCode)
+    }
+}

--- a/voorhees-server/src/test/kotlin/com/hylamobile/voorhees/server/spring/TestServiceTest.kt
+++ b/voorhees-server/src/test/kotlin/com/hylamobile/voorhees/server/spring/TestServiceTest.kt
@@ -519,6 +519,72 @@ class TestServiceTest {
             .andExpect(jsonPath("jsonrpc").value(`is`("2.0")))
     }
 
+    @Test
+    fun `get method is not allowed`() {
+        val request = Request("plus", ByPositionParams(3, 4), NumberId(1))
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/test")
+            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .accept(MediaType.APPLICATION_JSON)
+            .content(request.jsonString))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isMethodNotAllowed)
+    }
+
+    @Test
+    fun `put method is not allowed`() {
+        val request = Request("plus", ByPositionParams(3, 4), NumberId(1))
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/test")
+            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .accept(MediaType.APPLICATION_JSON)
+            .content(request.jsonString))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isMethodNotAllowed)
+    }
+
+    @Test
+    fun `patch method is not allowed`() {
+        val request = Request("plus", ByPositionParams(3, 4), NumberId(1))
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/test")
+            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .accept(MediaType.APPLICATION_JSON)
+            .content(request.jsonString))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isMethodNotAllowed)
+    }
+
+    @Test
+    fun `delete method is not allowed`() {
+        val request = Request("plus", ByPositionParams(3, 4), NumberId(1))
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/test")
+            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .accept(MediaType.APPLICATION_JSON)
+            .content(request.jsonString))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isMethodNotAllowed)
+    }
+
+    @Test
+    fun `content_type text_xml is not supported`() {
+        val request = Request("plus", ByPositionParams(3, 4), NumberId(1))
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
+            .contentType(MediaType.TEXT_XML)
+            .accept(MediaType.APPLICATION_JSON)
+            .content(request.jsonString))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isUnsupportedMediaType)
+    }
+
+    @Test
+    fun `accept text_xml is not supported`() {
+        val request = Request("plus", ByPositionParams(3, 4), NumberId(1))
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/test")
+            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .accept(MediaType.TEXT_XML)
+            .content(request.jsonString))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isNotAcceptable)
+    }
+
     fun MockHttpServletRequestBuilder.basicAuth(username: String, password: String): MockHttpServletRequestBuilder =
         header("Authorization",
             "Basic ${Base64Utils.encodeToString("$username:$password".toByteArray(Charsets.UTF_8))}")


### PR DESCRIPTION
* 405 Method Not Allowed if method is not POST
* 415 Unsupported Media Type if Content-Type is not JSON
* 406 Not Acceptable if Accept is not JSON

Fix #47